### PR TITLE
Docker and Postgres changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # service_app
 Service application in Spring 3.4.2 (Java)
+
+## Running with Docker
+
+This project includes a Docker setup for building and running the Spring 3.4.2 Java service. The provided `Dockerfile` uses Eclipse Temurin JDK 21 for building and JRE 21 for running the application. The service exposes port **8181**.
+
+### Build and Run
+
+To build and start the service using Docker Compose:
+
+```sh
+docker compose up --build
+```
+
+This will build the application image and start the `java-service_app` container, mapping port 8181 on your host to the service.
+
+### Configuration
+- **Port:** The application runs on port `8181` (as set in `application.properties` and exposed in the Dockerfile and compose file).
+- **Environment Variables:** No required environment variables are set by default. You may uncomment and use an `.env` file in `docker-compose.yml` if needed for your setup.
+- **Dependencies:** No external services (databases, caches, etc.) are required or configured by default.
+
+No additional configuration is needed for a basic run. For customizations, edit the `docker-compose.yml` or `application.properties` as needed.

--- a/pom.xml
+++ b/pom.xml
@@ -45,16 +45,25 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
-<!--	To use the H2 in-memory database with Spring Boot. This enables H2 for development and testing purposes.	-->
+<!--	To use the H2 in-memory database with Spring Boot.
+This enables H2 for development and testing purposes.	-->
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-<!--	To use Spring JDBC. This provides the necessary libraries for JDBC support in Spring Boot.	-->
+<!--	To use Spring JDBC.
+This provides the necessary libraries for JDBC support in Spring Boot.	-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
+<!--		Add the following dependency to your pom.xml to include the PostgreSQL JDBC driver.
+ This allows your Spring Boot application to connect to a PostgreSQL database.-->
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.3</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,14 @@
 spring.application.name=serviceApp
 server.port=8181
 
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
+# Connecting to in memory database H2
+#spring.datasource.url=jdbc:h2:mem:testdb
+#spring.datasource.driverClassName=org.h2.Driver
+#spring.datasource.username=sa
+#spring.datasource.password=password
+
+# Connecting to PostGres SQL database
+#spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+#spring.datasource.driver-class-name=org.postgresql.Driver
+#spring.datasource.username=postgres
+#spring.datasource.password=postgres


### PR DESCRIPTION
Your compose.yaml file is correct for running a Spring Boot app (java-service_app) and a PostgreSQL database (db) as separate services. The configuration exposes the necessary ports and sets up the required environment variables for PostgreSQL.  Explanation:  
The java-service_app service builds from your Dockerfile and exposes port 8181.
The db service uses the official postgres image, exposes port 5432, and sets up default credentials.
Both services will run in the same Docker network by default, allowing your app to connect to the database using the service name db as the host.