### PR TITLE
Test and Stable build changes

### DIFF
--- a/src/main/java/com/dev/serviceApp/controller/BookController.java
+++ b/src/main/java/com/dev/serviceApp/controller/BookController.java
@@ -1,0 +1,29 @@
+package com.dev.serviceApp.controller;
+
+import com.dev.serviceApp.domain.Books;
+import lombok.extern.java.Log;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Log
+public class BookController {
+//    @GetMapping(path = "/books")
+//    public Books retireveBook() {
+////        log.info("Retrieving book details");
+//        return Books.builder()
+//                .isbn("978-0134686097")
+//                .name("Effective Java")
+//                .author("Aria Montogemy")
+//                .yearPublished("2005")
+//                .build();
+//    }
+
+    @PostMapping(path = "/books")
+    public Books createBook(Books book) {
+//        log.info("Creating book: " + book);
+        // Here you would typically save the book to a database
+        return book;
+    }
+}

--- a/src/main/java/com/dev/serviceApp/domain/Authors.java
+++ b/src/main/java/com/dev/serviceApp/domain/Authors.java
@@ -6,18 +6,18 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-@Entity
-@Table(name = "authors")
-// This class represents the Authors entity in the application.
-public class Authors {
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "author_id_seq")
-    private Long id;
-    private String name;
-    private Integer age;
-
-}
+//@Data
+//@AllArgsConstructor
+//@NoArgsConstructor
+//@Builder
+//@Entity
+//@Table(name = "authors")
+//// This class represents the Authors entity in the application.
+//public class Authors {
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "author_id_seq")
+//    private Long id;
+//    private String name;
+//    private Integer age;
+//
+//}

--- a/src/main/java/com/dev/serviceApp/domain/Books.java
+++ b/src/main/java/com/dev/serviceApp/domain/Books.java
@@ -17,10 +17,13 @@ public class Books {
     private String isbn;
     private String name;
 
+    private String author;
+    private String yearPublished;
+
 
 //    private Long author_id;
-    @ManyToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "'author_id'") //, referencedColumnName = "id"
-    private Authors author; // Assuming you want to use the Authors entity as a reference
+//    @ManyToOne(cascade = CascadeType.ALL)
+//    @JoinColumn(name = "'author_id'") //, referencedColumnName = "id"
+//    private Authors author; // Assuming you want to use the Authors entity as a reference
 }
 

--- a/src/main/java/com/dev/serviceApp/repositories/AuthorRepository.java
+++ b/src/main/java/com/dev/serviceApp/repositories/AuthorRepository.java
@@ -1,12 +1,16 @@
 package com.dev.serviceApp.repositories;
 
-import com.dev.serviceApp.domain.Authors;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface AuthorRepository  extends CrudRepository<Authors, Long> {
-
-    Iterable<Authors> ageLessThan(Integer age);
-
-}
+//import com.dev.serviceApp.domain.Authors;
+//import org.springframework.data.jpa.repository.Query;
+//import org.springframework.data.repository.CrudRepository;
+//import org.springframework.stereotype.Repository;
+//
+//@Repository
+//public interface AuthorRepository  extends CrudRepository<Authors, Long> {
+//
+//    Iterable<Authors> ageLessThan(Integer age);
+//
+//    @Query("SELECT a FROM Authors a WHERE a.age > ?1")
+//    Iterable<Authors> ageGreaterThan(Integer age);
+//
+//}

--- a/src/test/java/com/dev/serviceApp/TestDataUtil.java
+++ b/src/test/java/com/dev/serviceApp/TestDataUtil.java
@@ -1,6 +1,6 @@
 package com.dev.serviceApp;
 
-import com.dev.serviceApp.domain.Authors;
+//import com.dev.serviceApp.domain.Authors;
 import com.dev.serviceApp.domain.Books;
 
 public final class TestDataUtil {

--- a/src/test/java/com/dev/serviceApp/repositories/AuthorRepositoryIntegrationTests.java
+++ b/src/test/java/com/dev/serviceApp/repositories/AuthorRepositoryIntegrationTests.java
@@ -1,7 +1,7 @@
 package com.dev.serviceApp.repositories;
 
 import com.dev.serviceApp.TestDataUtil;
-import com.dev.serviceApp.domain.Authors;
+//import com.dev.serviceApp.domain.Authors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,12 +15,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 public class AuthorRepositoryIntegrationTests {
-    private AuthorRepository authorDao;
-
-    @Autowired
-    public AuthorRepositoryIntegrationTests(AuthorRepository underTest) {
-        this.authorDao = underTest;
-    }
+//    private AuthorRepository authorDao;
+//
+//    @Autowired
+//    public AuthorRepositoryIntegrationTests(AuthorRepository underTest) {
+//        this.authorDao = underTest;
+//    }
 
 //    @Test
 //    public void testThatAuthorCanBeCreatedandRecalled () {


### PR DESCRIPTION
In the context of Spring, "Jakarta" refers to the Jakarta EE (formerly Java EE) set of specifications for enterprise Java development. Many core technologies used in Spring—such as Servlets, JSP, JPA, and JMS—originate from Jakarta EE.

Spring uses Jakarta EE APIs for:
- Dependency injection (`jakarta.inject`)
- Persistence (`jakarta.persistence`)
- Servlet API (`jakarta.servlet`)
- Validation (`jakarta.validation`)

Since Java EE was renamed to Jakarta EE, package names changed from `javax.*` to `jakarta.*`. Modern Spring versions use these `jakarta.*` packages for compatibility with the latest Jakarta EE standards.

Jackson is a popular Java library for serializing Java objects to JSON and deserializing JSON to Java objects. It is widely used in Spring Boot for handling JSON in REST APIs.

**Key features:**
- Converts Java objects to JSON (`ObjectMapper.writeValueAsString(obj)`)
- Converts JSON to Java objects (`ObjectMapper.readValue(json, Class.class)`)
- Supports custom serializers/deserializers
- Integrates with Spring Boot automatically via `spring-boot-starter-web`

**Basic usage example:**
```java
import com.fasterxml.jackson.databind.ObjectMapper;

ObjectMapper mapper = new ObjectMapper();
String json = mapper.writeValueAsString(myObject); // Serialize
MyClass obj = mapper.readValue(json, MyClass.class); // Deserialize
```

Spring Boot auto-configures Jackson for you, so you usually don’t need to configure it manually.
The `@Query` annotation in Spring Data JPA allows you to define custom JPQL or SQL queries directly on repository methods.

**Usage:**
- Place `@Query` above a repository method.
- Write JPQL (using entity and field names) or native SQL (set `nativeQuery = true`).

**Example:**
```java
@Query("SELECT a FROM Authors a WHERE a.age > ?1")
Iterable<Authors> ageGreaterThan(Integer age);
```
This fetches all `Authors` with `age` greater than the provided value.

**Native SQL Example:**
```java
@Query(value = "SELECT * FROM authors WHERE age > ?1", nativeQuery = true)
Iterable<Authors> ageGreaterThanNative(Integer age);
```
Use `@Query` for complex queries not supported by method naming conventions.